### PR TITLE
Add composer installation instructions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+composer.phar
+/vendor/
+
+# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+composer.lock

--- a/README.md
+++ b/README.md
@@ -5,7 +5,44 @@ That means if the user closes by mistake the browser (by mistake or by a system 
 
 ## Installation
 
-Download and unpack add-on to `<cockpit-folder>/addons/Autosave` folder.
+### Manual
+
+Download [latest release](https://github.com/pauloamgomes/CockpitCMS-Autosave) and extract to `COCKPIT_PATH/addons/Autosave` directory
+
+### Git
+
+```sh
+git clone https://github.com/pauloamgomes/CockpitCMS-Autosave.git ./addons/Autosave
+```
+
+### Cockpit CLI
+
+```sh
+php ./cp install/addon --name Autosave --url https://github.com/pauloamgomes/CockpitCMS-Autosave.git
+```
+
+### Composer
+
+1. Make sure path to cockpit addons is defined in your projects' _composer.json_ file:
+
+  ```json
+  {
+      "name": "MY_PROJECT",
+      "extra": {
+          "installer-paths": {
+              "cockpit/addons/{$name}": ["type:cockpit-module"]
+          }
+      }
+  }
+  ```
+
+2. In your project root run:
+
+  ```sh
+  composer require pauloamgomes/cockpitcms-autosave
+  ```
+
+---
 
 ## Configuration
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Cockpit autosave editor addon
+ *
+ * @author  Paulo Gomes
+ * @package CockpitCMS-Autosave
+ * @license MIT
+ *
+ * @source  https://github.com/pauloamgomes/CockpitCMS-Autosave
+ * @see     { README.md } for usage info.
+ */
 
 if (COCKPIT_ADMIN && !COCKPIT_API_REQUEST) {
   $this->module('autosave')->extend([
@@ -87,4 +97,3 @@ if (COCKPIT_ADMIN && !COCKPIT_API_REQUEST) {
 if (COCKPIT_API_REQUEST) {
   include_once __DIR__ . '/actions.php';
 }
-

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "pauloamgomes/cockpitcms-autosave",
+    "description": "Autosave addon for Cockpit CMS, provides autosave capabilities for collections and singletons",
+    "keywords": ["cms", "headless", "api", "cockpit", "autosave-addon"],
+    "homepage": "https://github.com/pauloamgomes/CockpitCMS-Autosave",
+    "license": "MIT",
+    "type": "cockpit-module",
+    "authors": [
+        {
+            "name": "Paulo Gomes",
+            "email": "pauloamgomes@gmail.com",
+            "homepage": "https://www.pauloamgomes.net"
+        }
+    ],
+    "require": {
+      "php": ">= 7.3",
+      "composer/installers": "^1.10"
+    },
+    "suggest": {
+      "aheinze/cockpit": "Please install Cockpit before installing this addon"
+    },
+    "extra": {
+      "installer-name": "Autosave"
+    }
+}


### PR DESCRIPTION
Related to: https://github.com/pauloamgomes/CockpitCMS-BetterSlugs/pull/9

---

**List of changes:**

- added alternative installation instructions (as proposed by [piotr-cz](https://github.com/composer/installers/pull/284))
- added some PHP Docs
